### PR TITLE
Hooks with type parameters

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/intuit/hooks/plugin/CodeGeneration.kt
+++ b/compiler-plugin/src/main/kotlin/com/intuit/hooks/plugin/CodeGeneration.kt
@@ -32,7 +32,7 @@ internal enum class HookType(vararg val properties: HookProperty) {
     SyncHook {
         override fun generateClass(codeGen: HookCodeGen): String {
             // todo: potentially protected
-            return """|class ${codeGen.className} : ${codeGen.superType}<${codeGen.typeParameter}>() {
+            return """|inner class ${codeGen.className} : ${codeGen.superType}<${codeGen.typeParameter}>() {
                       |    fun call(${codeGen.paramsWithTypes}) = super.call { f, context -> f(context, ${codeGen.paramsWithoutTypes}) }
                       |    ${codeGen.tapMethod}
                       |}"""
@@ -41,7 +41,7 @@ internal enum class HookType(vararg val properties: HookProperty) {
     SyncBailHook(HookProperty.Bail) {
         override fun generateClass(codeGen: HookCodeGen): String {
             // todo: Potentially protected
-            return """|class ${codeGen.className} : ${codeGen.superType}<${codeGen.typeParameter}, ${codeGen.hookSignature.returnTypeType}>() {
+            return """|inner class ${codeGen.className} : ${codeGen.superType}<${codeGen.typeParameter}, ${codeGen.hookSignature.returnTypeType}>() {
                       |    fun call(${codeGen.paramsWithTypes}) = super.call { f, context -> f(context, ${codeGen.paramsWithoutTypes}) }
                       |    ${codeGen.tapMethod}
                       |}"""
@@ -50,7 +50,7 @@ internal enum class HookType(vararg val properties: HookProperty) {
     SyncWaterfallHook(HookProperty.Waterfall) {
         override fun generateClass(codeGen: HookCodeGen): String {
             val accumulatorName = codeGen.params.first().withoutType
-            return """|class ${codeGen.className} : ${codeGen.superType}<${codeGen.typeParameter}, ${codeGen.params.first().type}>() {
+            return """|inner class ${codeGen.className} : ${codeGen.superType}<${codeGen.typeParameter}, ${codeGen.params.first().type}>() {
                       |    fun call(${codeGen.paramsWithTypes}) = super.call($accumulatorName,
                       |        invokeTap = { f, $accumulatorName, context -> f(context, ${codeGen.paramsWithoutTypes}) },
                       |        invokeInterceptor = { f, context -> f(context, ${codeGen.paramsWithoutTypes})}
@@ -62,7 +62,7 @@ internal enum class HookType(vararg val properties: HookProperty) {
 
     SyncLoopHook(HookProperty.Loop) {
         override fun generateClass(codeGen: HookCodeGen): String {
-            return """|class ${codeGen.className}: ${codeGen.superType}<${codeGen.typeParameter}, ${codeGen.interceptParameter}>() {
+            return """|inner class ${codeGen.className}: ${codeGen.superType}<${codeGen.typeParameter}, ${codeGen.interceptParameter}>() {
                       |    fun call(${codeGen.paramsWithTypes}) = super.call(
                       |         invokeTap = { f, context -> f(context, ${codeGen.paramsWithoutTypes}) },
                       |         invokeInterceptor = { f, context -> f(context, ${codeGen.paramsWithoutTypes}) }
@@ -74,7 +74,7 @@ internal enum class HookType(vararg val properties: HookProperty) {
 
     AsyncParallelHook(HookProperty.Async) {
         override fun generateClass(codeGen: HookCodeGen): String {
-            return """|class ${codeGen.className}: ${codeGen.superType}<${codeGen.typeParameter}>() {
+            return """|inner class ${codeGen.className}: ${codeGen.superType}<${codeGen.typeParameter}>() {
                       |    suspend fun call(scope: CoroutineScope, ${codeGen.paramsWithTypes}) = super.call(scope) { f, context -> f(context, ${codeGen.paramsWithoutTypes}) }
                       |    ${codeGen.tapMethod}
                       |}"""
@@ -84,7 +84,7 @@ internal enum class HookType(vararg val properties: HookProperty) {
     AsyncParallelBailHook(HookProperty.Async, HookProperty.Bail) {
         override fun generateClass(codeGen: HookCodeGen): String {
             return """|@kotlinx.coroutines.ExperimentalCoroutinesApi
-                      |class ${codeGen.className}: ${codeGen.superType}<${codeGen.typeParameter}, ${codeGen.hookSignature.returnTypeType}>() {
+                      |inner class ${codeGen.className}: ${codeGen.superType}<${codeGen.typeParameter}, ${codeGen.hookSignature.returnTypeType}>() {
                       |    suspend fun call(scope: CoroutineScope, concurrency: Int,  ${codeGen.paramsWithTypes}) = super.call(scope, concurrency) { f, context -> f(context, ${codeGen.paramsWithoutTypes}) }
                       |    ${codeGen.tapMethod}
                       |}"""
@@ -93,7 +93,7 @@ internal enum class HookType(vararg val properties: HookProperty) {
 
     AsyncSeriesHook(HookProperty.Async) {
         override fun generateClass(codeGen: HookCodeGen): String {
-            return """|class ${codeGen.className}: ${codeGen.superType}<${codeGen.typeParameter}>() {
+            return """|inner class ${codeGen.className}: ${codeGen.superType}<${codeGen.typeParameter}>() {
                       |    suspend fun call(${codeGen.paramsWithTypes}) = super.call { f, context -> f(context, ${codeGen.paramsWithoutTypes}) }
                       |    ${codeGen.tapMethod}
                       |}"""
@@ -102,7 +102,7 @@ internal enum class HookType(vararg val properties: HookProperty) {
 
     AsyncSeriesBailHook(HookProperty.Async, HookProperty.Bail) {
         override fun generateClass(codeGen: HookCodeGen): String {
-            return """|class ${codeGen.className}: ${codeGen.superType}<${codeGen.typeParameter}, ${codeGen.hookSignature.returnTypeType}>() {
+            return """|inner class ${codeGen.className}: ${codeGen.superType}<${codeGen.typeParameter}, ${codeGen.hookSignature.returnTypeType}>() {
                       |    suspend fun call(${codeGen.paramsWithTypes}) = super.call { f, context -> f(context, ${codeGen.paramsWithoutTypes}) }
                       |    ${codeGen.tapMethod}
                       |}"""
@@ -112,7 +112,7 @@ internal enum class HookType(vararg val properties: HookProperty) {
     AsyncSeriesWaterfallHook(HookProperty.Async, HookProperty.Waterfall) {
         override fun generateClass(codeGen: HookCodeGen): String {
             val accumulatorName = codeGen.params.first().withoutType
-            return """|class ${codeGen.className} : ${codeGen.superType}<${codeGen.typeParameter}, ${codeGen.params.first().type}>() {
+            return """|inner class ${codeGen.className} : ${codeGen.superType}<${codeGen.typeParameter}, ${codeGen.params.first().type}>() {
                       |    suspend fun call(${codeGen.paramsWithTypes}) = super.call($accumulatorName,
                       |        invokeTap = { f, $accumulatorName, context -> f(context, ${codeGen.paramsWithoutTypes}) },
                       |        invokeInterceptor = { f, context -> f(context, ${codeGen.paramsWithoutTypes})}
@@ -124,7 +124,7 @@ internal enum class HookType(vararg val properties: HookProperty) {
 
     AsyncSeriesLoopHook(HookProperty.Async, HookProperty.Loop) {
         override fun generateClass(codeGen: HookCodeGen): String {
-            return """|class ${codeGen.className}: ${codeGen.superType}<${codeGen.typeParameter}, ${codeGen.interceptParameter}>() {
+            return """|inner class ${codeGen.className}: ${codeGen.superType}<${codeGen.typeParameter}, ${codeGen.interceptParameter}>() {
                       |    suspend fun call(${codeGen.paramsWithTypes}) = super.call(
                       |         invokeTap = { f, context -> f(context, ${codeGen.paramsWithoutTypes}) },
                       |         invokeInterceptor = { f, context -> f(context, ${codeGen.paramsWithoutTypes}) }

--- a/compiler-plugin/src/main/kotlin/com/intuit/hooks/plugin/Hooks.kt
+++ b/compiler-plugin/src/main/kotlin/com/intuit/hooks/plugin/Hooks.kt
@@ -28,7 +28,7 @@ internal val Meta.hooks: CliPlugin
                            |
                            |$imports
                            |
-                           |$kind ${name}Impl : $name() {
+                           |$kind ${name}Impl${this.`(typeParameters)`} : $name${this.`(typeParameters)`}() {
                            |   ${properties.map { it.property(null).syntheticElement }.joinToString("\n")}
                            |   ${classes.map { it.`class`.syntheticScope }.joinToString("\n")} 
                            |}""".trimMargin().file("${name}Impl")

--- a/compiler-plugin/src/main/kotlin/com/intuit/hooks/plugin/Hooks.kt
+++ b/compiler-plugin/src/main/kotlin/com/intuit/hooks/plugin/Hooks.kt
@@ -29,7 +29,7 @@ internal val Meta.hooks: CliPlugin
                            |$imports
                            |
                            |$kind ${name}Impl : $name() {
-                           |   ${properties.map { it.property.syntheticScope }.joinToString("\n")}
+                           |   ${properties.map { it.property(null).syntheticElement }.joinToString("\n")}
                            |   ${classes.map { it.`class`.syntheticScope }.joinToString("\n")} 
                            |}""".trimMargin().file("${name}Impl")
 

--- a/compiler-plugin/src/test/kotlin/com/intuit/hooks/plugin/HookTest.kt
+++ b/compiler-plugin/src/test/kotlin/com/intuit/hooks/plugin/HookTest.kt
@@ -112,4 +112,38 @@ class HookTest {
             )
         )
     }
+
+    @Test
+    fun testHookWithTypeParameter() {
+        val testHookClass =
+            """
+|package com.intuit.hooks.plugin.test
+|import com.intuit.hooks.dsl.Hooks
+|
+|abstract class TestHooks<T> : Hooks() {
+|    open val testSyncHook = syncHook<(T) -> Unit>()
+|}
+"""
+        val testHookCall =
+            """
+|fun testHook() : Boolean { 
+|   var tapCalled = false
+|   val hooks = TestHooksImpl<String>()
+|   hooks.testSyncHook.tap("test") { _, x -> tapCalled = true }
+|   hooks.testSyncHook.call("hello")
+|   return tapCalled
+|}"""
+        assertThis(
+            CompilerTest(
+                config = { hookDependencies() },
+                code = {
+                    (testHookClass + testHookCall).source
+                },
+
+                assert = {
+                    "testHook()".source.evalsTo(true)
+                }
+            )
+        )
+    }
 }


### PR DESCRIPTION
# What Changed

This adds the ability to use Hooks with type parameters. The use case for this is when some piece of data is known only to the consumer of a library and the consumers of the taps, but not necessarily the library itself. As an example:

```kotlin
class FooHooks<T> : Hooks() {
    open val beforeCalc = syncHook<(T) -> Unit>()
}

data class Foo<T>(val t: T)  {
    public val hooks = FooHooksImpl<T>()

    fun calc() {
        hooks.beforeCalc.call(t)
        // ...
    }
}

fun runCalcsWithLog() {
    val f = Foo<String>("hi")
    f.hooks.beforeCalc.tap("hi") { x -> println(x) }
}
```

Todo:

- [x] Add tests
- [ ] Add docs
- [x] Add release notes

# Release Notes

Enhance DSL to adds the ability to generate Hooks with type parameters. The use case for this is when some piece of data is known only to the consumer of a library and the consumers of the taps, but not necessarily the library itself. As an example:

```kotlin
class FooHooks<T> : Hooks() {
    open val beforeCalc = syncHook<(T) -> Unit>()
}

data class Foo<T>(val t: T)  {
    public val hooks = FooHooksImpl<T>()

    fun calc() {
        hooks.beforeCalc.call(t)
        // ...
    }
}

fun runCalcsWithLog() {
    val f = Foo<String>("hi")
    f.hooks.beforeCalc.tap("hi") { x -> println(x) }
}
```