### PR TITLE
New Hooks DSL

### DIFF
--- a/docs/src/orchid/resources/wiki/key-concepts.md
+++ b/docs/src/orchid/resources/wiki/key-concepts.md
@@ -82,10 +82,10 @@ Every plugin and some interceptors have access to a `HookContext`, which can be 
 
 <!--- INCLUDE
 import com.intuit.hooks.dsl.Hooks
-import com.intuit.hooks.SyncHook
+import com.intuit.hooks.Hook
 
 abstract class CarHooks : Hooks() {
-    @Sync<(newSpeed: Int) -> Unit> abstract val accelerate: SyncHook<*>
+    @Sync<(newSpeed: Int) -> Unit> abstract val accelerate: Hook
 }
 
 class Car {

--- a/docs/src/orchid/resources/wiki/plugin-architecture.md
+++ b/docs/src/orchid/resources/wiki/plugin-architecture.md
@@ -8,16 +8,16 @@ Cars come with many features that can vary heavily depending on the make, model,
 
 <!--- INCLUDE
 import com.intuit.hooks.dsl.Hooks
-import com.intuit.hooks.SyncHook
+import com.intuit.hooks.Hook
 -->
 
 ```kotlin
 abstract class CarHooks : Hooks() {
     @Sync<() -> Unit>
-    abstract val brake: SyncHook<*>
+    abstract val brake: Hook
     
     @Sync<(newSpeed: Int) -> Unit>
-    abstract val accelerate: SyncHook<*>
+    abstract val accelerate: Hook
 }
 
 ```
@@ -65,14 +65,14 @@ In the snippet above, loggers were tapped to each hook from the `car` reference.
 
 <!--- INCLUDE
 import com.intuit.hooks.dsl.Hooks
-import com.intuit.hooks.SyncHook
+import com.intuit.hooks.Hook
 
 abstract class CarHooks : Hooks() {
     @Sync<() -> Unit>
-    abstract val brake: SyncHook<*>
+    abstract val brake: Hook
     
     @Sync<(newSpeed: Int) -> Unit>
-    abstract val accelerate: SyncHook<*>
+    abstract val accelerate: Hook
 }
 -->
 

--- a/docs/src/test/kotlin/example/example-car-01.kt
+++ b/docs/src/test/kotlin/example/example-car-01.kt
@@ -2,14 +2,14 @@
 package com.intuit.hooks.example.exampleCar01
 
 import com.intuit.hooks.dsl.Hooks
-import com.intuit.hooks.SyncHook
+import com.intuit.hooks.Hook
 
 abstract class CarHooks : Hooks() {
     @Sync<() -> Unit>
-    abstract val brake: SyncHook<*>
+    abstract val brake: Hook
     
     @Sync<(newSpeed: Int) -> Unit>
-    abstract val accelerate: SyncHook<*>
+    abstract val accelerate: Hook
 }
 
 class Car {

--- a/docs/src/test/kotlin/example/example-car-02.kt
+++ b/docs/src/test/kotlin/example/example-car-02.kt
@@ -2,14 +2,14 @@
 package com.intuit.hooks.example.exampleCar02
 
 import com.intuit.hooks.dsl.Hooks
-import com.intuit.hooks.SyncHook
+import com.intuit.hooks.Hook
 
 abstract class CarHooks : Hooks() {
     @Sync<() -> Unit>
-    abstract val brake: SyncHook<*>
+    abstract val brake: Hook
     
     @Sync<(newSpeed: Int) -> Unit>
-    abstract val accelerate: SyncHook<*>
+    abstract val accelerate: Hook
 }
 
 class Car(vararg plugins: Plugin) {

--- a/docs/src/test/kotlin/example/example-context-01.kt
+++ b/docs/src/test/kotlin/example/example-context-01.kt
@@ -2,10 +2,10 @@
 package com.intuit.hooks.example.exampleContext01
 
 import com.intuit.hooks.dsl.Hooks
-import com.intuit.hooks.SyncHook
+import com.intuit.hooks.Hook
 
 abstract class CarHooks : Hooks() {
-    @Sync<(newSpeed: Int) -> Unit> abstract val accelerate: SyncHook<*>
+    @Sync<(newSpeed: Int) -> Unit> abstract val accelerate: Hook
 }
 
 class Car {

--- a/docs/src/test/kotlin/example/example-dsl-01.kt
+++ b/docs/src/test/kotlin/example/example-dsl-01.kt
@@ -5,16 +5,16 @@ import com.intuit.hooks.*
 import com.intuit.hooks.dsl.Hooks
 
 internal abstract class GenericHooks : Hooks() {
-    @Sync<(newSpeed: Int) -> Unit> abstract val sync: SyncHook<*>
-    @SyncBail<(Boolean) -> BailResult<Int>> abstract val syncBail: SyncBailHook<*, *>
-    @SyncLoop<(foo: Boolean) -> LoopResult> abstract val syncLoop: SyncLoopHook<*, *>
-    @SyncWaterfall<(name: String) -> String> abstract val syncWaterfall: SyncWaterfallHook<*, *>
-    @AsyncParallelBail<suspend (String) -> BailResult<String>> abstract val asyncParallelBail: AsyncParallelBailHook<*, *>
-    @AsyncParallel<suspend (String) -> Int> abstract val asyncParallel: AsyncParallelHook<*>
-    @AsyncSeries<suspend (String) -> Int> abstract val asyncSeries: AsyncSeriesHook<*>
-    @AsyncSeriesBail<suspend (String) -> BailResult<String>> abstract val asyncSeriesBail: AsyncSeriesBailHook<*, *>
-    @AsyncSeriesLoop<suspend (String) -> LoopResult> abstract val asyncSeriesLoop: AsyncSeriesLoopHook<*, *>
-    @AsyncSeriesWaterfall<suspend (String) -> String> abstract val asyncSeriesWaterfall: AsyncSeriesWaterfallHook<*, *>
+    @Sync<(newSpeed: Int) -> Unit> abstract val sync: Hook
+    @SyncBail<(Boolean) -> BailResult<Int>> abstract val syncBail: Hook
+    @SyncLoop<(foo: Boolean) -> LoopResult> abstract val syncLoop: Hook
+    @SyncWaterfall<(name: String) -> String> abstract val syncWaterfall: Hook
+    @AsyncParallelBail<suspend (String) -> BailResult<String>> abstract val asyncParallelBail: Hook
+    @AsyncParallel<suspend (String) -> Int> abstract val asyncParallel: Hook
+    @AsyncSeries<suspend (String) -> Int> abstract val asyncSeries: Hook
+    @AsyncSeriesBail<suspend (String) -> BailResult<String>> abstract val asyncSeriesBail: Hook
+    @AsyncSeriesLoop<suspend (String) -> LoopResult> abstract val asyncSeriesLoop: Hook
+    @AsyncSeriesWaterfall<suspend (String) -> String> abstract val asyncSeriesWaterfall: Hook
 }
 
 fun main() {

--- a/docs/src/test/kotlin/example/snippets.kt
+++ b/docs/src/test/kotlin/example/snippets.kt
@@ -1,6 +1,7 @@
 package example
 
 import com.intuit.hooks.AsyncSeriesHook
+import com.intuit.hooks.Hook
 import com.intuit.hooks.HookContext
 import com.intuit.hooks.SyncHook
 import com.intuit.hooks.dsl.Hooks
@@ -55,7 +56,7 @@ fun typed() {
 // START concise_dsl
 abstract class SomeHooks : Hooks() {
     @Sync<() -> Unit>
-    abstract val syncHook: SyncHook<*>
+    abstract val syncHook: Hook
 }
 // END concise_dsl
 

--- a/example-library/src/main/kotlin/com/intuit/hooks/example/library/car/Car.kt
+++ b/example-library/src/main/kotlin/com/intuit/hooks/example/library/car/Car.kt
@@ -1,6 +1,7 @@
 package com.intuit.hooks.example.library.car
 
 import com.intuit.hooks.AsyncSeriesWaterfallHook
+import com.intuit.hooks.Hook
 import com.intuit.hooks.SyncHook
 import com.intuit.hooks.dsl.HooksDsl
 
@@ -13,13 +14,13 @@ public class Car {
     public abstract class Hooks : HooksDsl() {
 
         @Sync<(newSpeed: Int) -> Unit>
-        public abstract val accelerate: SyncHook<*>
+        public abstract val accelerate: Hook
 
         @Sync<() -> Unit>
-        public abstract val brake: SyncHook<*>
+        public abstract val brake: Hook
 
         @AsyncSeriesWaterfall<suspend (routesList: List<Route>, source: Location, target: Location) -> List<Route>>
-        public abstract val calculateRoutes: AsyncSeriesWaterfallHook<*, *>
+        public abstract val calculateRoutes: Hook
     }
 
     public val hooks: CarHooksImpl = CarHooksImpl()

--- a/example-library/src/main/kotlin/com/intuit/hooks/example/library/generic/GenericHooks.kt
+++ b/example-library/src/main/kotlin/com/intuit/hooks/example/library/generic/GenericHooks.kt
@@ -5,15 +5,15 @@ import com.intuit.hooks.dsl.Hooks
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 
 internal abstract class GenericHooks : Hooks() {
-    @Sync<(newSpeed: Int) -> Unit> abstract val sync: SyncHook<*>
-    @SyncBail<(Boolean) -> BailResult<Int>> abstract val syncBail: SyncBailHook<*, *>
-    @SyncLoop<(foo: Boolean) -> LoopResult> abstract val syncLoop: SyncLoopHook<*, *>
-    @SyncWaterfall<(name: String) -> String> abstract val syncWaterfall: SyncWaterfallHook<*, *>
+    @Sync<(newSpeed: Int) -> Unit> abstract val sync: Hook
+    @SyncBail<(Boolean) -> BailResult<Int>> abstract val syncBail: Hook
+    @SyncLoop<(foo: Boolean) -> LoopResult> abstract val syncLoop: Hook
+    @SyncWaterfall<(name: String) -> String> abstract val syncWaterfall: Hook
     @ExperimentalCoroutinesApi
-    @AsyncParallelBail<suspend (String) -> BailResult<String>> abstract val asyncParallelBail: AsyncParallelBailHook<*, *>
-    @AsyncParallel<suspend (String) -> Int> abstract val asyncParallel: AsyncParallelHook<*>
-    @AsyncSeries<suspend (String) -> Int> abstract val asyncSeries: AsyncSeriesHook<*>
-    @AsyncSeriesBail<suspend (String) -> BailResult<String>> abstract val asyncSeriesBail: AsyncSeriesBailHook<*, *>
-    @AsyncSeriesLoop<suspend (String) -> LoopResult> abstract val asyncSeriesLoop: AsyncSeriesLoopHook<*, *>
-    @AsyncSeriesWaterfall<suspend (String) -> String> abstract val asyncSeriesWaterfall: AsyncSeriesWaterfallHook<*, *>
+    @AsyncParallelBail<suspend (String) -> BailResult<String>> abstract val asyncParallelBail: Hook
+    @AsyncParallel<suspend (String) -> Int> abstract val asyncParallel: Hook
+    @AsyncSeries<suspend (String) -> Int> abstract val asyncSeries: Hook
+    @AsyncSeriesBail<suspend (String) -> BailResult<String>> abstract val asyncSeriesBail: Hook
+    @AsyncSeriesLoop<suspend (String) -> LoopResult> abstract val asyncSeriesLoop: Hook
+    @AsyncSeriesWaterfall<suspend (String) -> String> abstract val asyncSeriesWaterfall: Hook
 }

--- a/example-library/src/test/kotlin/CompilerPluginTest.kt
+++ b/example-library/src/test/kotlin/CompilerPluginTest.kt
@@ -20,7 +20,7 @@ class CompilerPluginTest {
                 "ksp",
                 "main",
                 "kotlin",
-            ).resolve("${it}Impl.kt")
+            ).resolve("${it}Hooks.kt")
         }.forEach {
             assertTrue(it.exists()) { "$it does not exist" }
         }

--- a/example-library/src/test/kotlin/CompilerPluginTest.kt
+++ b/example-library/src/test/kotlin/CompilerPluginTest.kt
@@ -10,7 +10,7 @@ class CompilerPluginTest {
     @Test
     fun `sources are generated in specified directory`() {
         val generatedDirPath = Paths.get(System.getProperty("user.dir"), "build", "generated")
-        listOf("car.CarHooks", "generic.GenericHooks").map {
+        listOf("car.Car", "generic.GenericHooks").map {
             "com.intuit.hooks.example.library.$it"
         }.map {
             Paths.get("", *it.split(".").toTypedArray())

--- a/gradle-plugin/src/test/kotlin/HooksGradlePluginTest.kt
+++ b/gradle-plugin/src/test/kotlin/HooksGradlePluginTest.kt
@@ -59,12 +59,12 @@ class HooksGradlePluginTest {
         }
         testHooks.appendKotlin(
             """
-            import com.intuit.hooks.SyncHook
+            import com.intuit.hooks.*
             import com.intuit.hooks.dsl.Hooks
             
             internal abstract class TestHooks : Hooks() {
                 @Sync<(String) -> Unit>
-                abstract val testSyncHook: SyncHook<*>
+                abstract val testSyncHook: Hook
             }
         """
         )

--- a/gradle-plugin/src/test/kotlin/HooksGradlePluginTest.kt
+++ b/gradle-plugin/src/test/kotlin/HooksGradlePluginTest.kt
@@ -77,6 +77,6 @@ class HooksGradlePluginTest {
             .build()
 
         assertEquals(TaskOutcome.SUCCESS, runner.task(":kspKotlin")?.outcome)
-        assertTrue(workingDir.resolve("build/generated/ksp/main/kotlin/TestHooksImpl.kt").exists())
+        assertTrue(workingDir.resolve("build/generated/ksp/main/kotlin/TestHooksHooks.kt").exists())
     }
 }

--- a/hooks/api/hooks.api
+++ b/hooks/api/hooks.api
@@ -49,7 +49,7 @@ public final class com/intuit/hooks/BailResult$Continue : com/intuit/hooks/BailR
 	public fun <init> ()V
 }
 
-public abstract class com/intuit/hooks/BaseHook {
+public abstract class com/intuit/hooks/BaseHook : com/intuit/hooks/Hook {
 	public fun <init> (Ljava/lang/String;)V
 	protected fun generateRandomId ()Ljava/lang/String;
 	protected fun getInterceptors ()Lcom/intuit/hooks/Interceptors;
@@ -60,6 +60,9 @@ public abstract class com/intuit/hooks/BaseHook {
 	public final fun tap (Ljava/lang/String;Ljava/lang/String;Lkotlin/Function;)Ljava/lang/String;
 	public final fun tap (Ljava/lang/String;Lkotlin/Function;)Ljava/lang/String;
 	public final fun untap (Ljava/lang/String;)V
+}
+
+public abstract class com/intuit/hooks/Hook {
 }
 
 public class com/intuit/hooks/Interceptors {

--- a/hooks/src/main/kotlin/com/intuit/hooks/BaseHook.kt
+++ b/hooks/src/main/kotlin/com/intuit/hooks/BaseHook.kt
@@ -70,7 +70,9 @@ public abstract class SyncBaseHook<F : Function<*>>(type: String) : BaseHook<F>(
     }
 }
 
-public abstract class BaseHook<F : Function<*>>(private val type: String) {
+public sealed class Hook
+
+public abstract class BaseHook<F : Function<*>>(private val type: String) : Hook() {
     protected var taps: List<TapInfo<F>> = emptyList(); private set
     protected open val interceptors: Interceptors<F> = Interceptors()
 

--- a/processor/README.md
+++ b/processor/README.md
@@ -38,16 +38,16 @@ import com.intuit.hooks.dsl.Hooks
 
 ```kotlin
 internal abstract class GenericHooks : Hooks() {
-    @Sync<(newSpeed: Int) -> Unit> abstract val sync: SyncHook<*>
-    @SyncBail<(Boolean) -> BailResult<Int>> abstract val syncBail: SyncBailHook<*, *>
-    @SyncLoop<(foo: Boolean) -> LoopResult> abstract val syncLoop: SyncLoopHook<*, *>
-    @SyncWaterfall<(name: String) -> String> abstract val syncWaterfall: SyncWaterfallHook<*, *>
-    @AsyncParallelBail<suspend (String) -> BailResult<String>> abstract val asyncParallelBail: AsyncParallelBailHook<*, *>
-    @AsyncParallel<suspend (String) -> Int> abstract val asyncParallel: AsyncParallelHook<*>
-    @AsyncSeries<suspend (String) -> Int> abstract val asyncSeries: AsyncSeriesHook<*>
-    @AsyncSeriesBail<suspend (String) -> BailResult<String>> abstract val asyncSeriesBail: AsyncSeriesBailHook<*, *>
-    @AsyncSeriesLoop<suspend (String) -> LoopResult> abstract val asyncSeriesLoop: AsyncSeriesLoopHook<*, *>
-    @AsyncSeriesWaterfall<suspend (String) -> String> abstract val asyncSeriesWaterfall: AsyncSeriesWaterfallHook<*, *>
+    @Sync<(newSpeed: Int) -> Unit> abstract val sync: Hook
+    @SyncBail<(Boolean) -> BailResult<Int>> abstract val syncBail: Hook
+    @SyncLoop<(foo: Boolean) -> LoopResult> abstract val syncLoop: Hook
+    @SyncWaterfall<(name: String) -> String> abstract val syncWaterfall: Hook
+    @AsyncParallelBail<suspend (String) -> BailResult<String>> abstract val asyncParallelBail: Hook
+    @AsyncParallel<suspend (String) -> Int> abstract val asyncParallel: Hook
+    @AsyncSeries<suspend (String) -> Int> abstract val asyncSeries: Hook
+    @AsyncSeriesBail<suspend (String) -> BailResult<String>> abstract val asyncSeriesBail: Hook
+    @AsyncSeriesLoop<suspend (String) -> LoopResult> abstract val asyncSeriesLoop: Hook
+    @AsyncSeriesWaterfall<suspend (String) -> String> abstract val asyncSeriesWaterfall: Hook
 }
 ```
 

--- a/processor/src/main/kotlin/com/intuit/hooks/plugin/codegen/HookInfo.kt
+++ b/processor/src/main/kotlin/com/intuit/hooks/plugin/codegen/HookInfo.kt
@@ -7,7 +7,6 @@ internal data class HooksContainer(
     val name: String,
     val originalClassName: ClassName,
     val typeSpecKind: TypeSpec.Kind,
-    val resolvedPackageName: String?,
     val visibilityModifier: KModifier,
     val typeArguments: List<TypeVariableName>,
     val hooks: List<HookInfo>

--- a/processor/src/main/kotlin/com/intuit/hooks/plugin/codegen/Poet.kt
+++ b/processor/src/main/kotlin/com/intuit/hooks/plugin/codegen/Poet.kt
@@ -10,7 +10,6 @@ internal fun HookInfo.createSuperClass(extraTypeName: TypeName? = null): Paramet
     val lambdaParameter = lambdaTypeName
     val parameters = listOfNotNull(lambdaParameter, extraTypeName)
 
-    // TODO: is there a way to avoid bestGuess here?
     return ClassName.bestGuess("com.intuit.hooks.$superType")
         .parameterizedBy(parameters)
 }
@@ -174,7 +173,6 @@ internal val HookType.addedAnnotation: AnnotationSpec? get() = when (this) {
 internal fun HookInfo.generateProperty(): PropertySpec =
     PropertySpec.builder(property, ClassName.bestGuess(className)).apply {
         initializer("$className()")
-        // TODO: the visibility here might not be correct
         addModifiers(KModifier.OVERRIDE, propertyVisibility)
         hookType.addedAnnotation?.let(::addAnnotation)
     }.build()

--- a/processor/src/main/kotlin/com/intuit/hooks/plugin/codegen/Poet.kt
+++ b/processor/src/main/kotlin/com/intuit/hooks/plugin/codegen/Poet.kt
@@ -15,10 +15,12 @@ internal fun HookInfo.createSuperClass(extraTypeName: TypeName? = null): Paramet
         .parameterizedBy(parameters)
 }
 
-internal fun HooksContainer.generateFile(): FileSpec =
-    FileSpec.builder(resolvedPackageName ?: "", name)
-        .addType(generateContainerClass())
-        .build()
+internal fun generateFile(resolvedPackageName: String, name: String, hookContainers: List<HooksContainer>): FileSpec =
+    FileSpec.builder(resolvedPackageName, name).apply {
+        hookContainers
+            .map(HooksContainer::generateContainerClass)
+            .forEach(::addType)
+    }.build()
 
 private fun HooksContainer.generateContainerClass(): TypeSpec {
     val className = ClassName.bestGuess(name)

--- a/processor/src/main/kotlin/com/intuit/hooks/plugin/ksp/HooksProcessor.kt
+++ b/processor/src/main/kotlin/com/intuit/hooks/plugin/ksp/HooksProcessor.kt
@@ -51,7 +51,7 @@ public class HooksProcessor(
                 }
             }.toList()
 
-            if(hookContainers.isEmpty()) return
+            if (hookContainers.isEmpty()) return
 
             val packageName = file.packageName.asString()
             val name = file.fileName.split(".").first()
@@ -112,7 +112,6 @@ public class HooksProcessor(
         override fun defaultHandler(node: KSNode, data: Unit): List<ValidatedNel<HookValidationError, HooksContainer>> =
             TODO("Not yet implemented")
     }
-
 
     public class Provider : SymbolProcessorProvider {
         override fun create(environment: SymbolProcessorEnvironment): HooksProcessor = HooksProcessor(

--- a/processor/src/main/kotlin/com/intuit/hooks/plugin/ksp/HooksProcessor.kt
+++ b/processor/src/main/kotlin/com/intuit/hooks/plugin/ksp/HooksProcessor.kt
@@ -1,13 +1,14 @@
 package com.intuit.hooks.plugin.ksp
 
-import arrow.core.sequence
-import arrow.core.valueOr
+import arrow.core.*
 import arrow.typeclasses.Semigroup
 import com.google.devtools.ksp.getVisibility
 import com.google.devtools.ksp.processing.*
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.validate
+import com.google.devtools.ksp.visitor.KSDefaultVisitor
 import com.intuit.hooks.plugin.codegen.*
+import com.intuit.hooks.plugin.ksp.validation.HookValidationError
 import com.intuit.hooks.plugin.ksp.validation.validateProperty
 import com.squareup.kotlinpoet.*
 import com.squareup.kotlinpoet.ksp.*
@@ -19,77 +20,98 @@ public class HooksProcessor(
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
         resolver.getNewFiles().forEach {
-            it.accept(HooksVisitor(), Unit)
+            it.accept(HookFileVisitor(), Unit)
         }
 
         return emptyList()
     }
 
-    private inner class HooksVisitor : KSVisitorVoid() {
-
-        override fun visitFile(file: KSFile, data: Unit) {
-            file.declarations.filter {
-                it is KSClassDeclaration
-            }.forEach {
-                it.accept(this, Unit)
-            }
+    private inner class HookPropertyVisitor : KSDefaultVisitor<TypeParameterResolver, ValidatedNel<HookValidationError, HookInfo>>() {
+        override fun visitPropertyDeclaration(property: KSPropertyDeclaration, parentResolver: TypeParameterResolver): ValidatedNel<HookValidationError, HookInfo> {
+            return if (property.modifiers.contains(Modifier.ABSTRACT))
+                validateProperty(property, parentResolver)
+            else
+                HookValidationError.NotAnAbstractProperty(property).invalidNel()
         }
 
-        override fun visitClassDeclaration(classDeclaration: KSClassDeclaration, data: Unit) {
-            // TODO: This should really be restructured to follow KSP visitor pattern for members
+        override fun defaultHandler(node: KSNode, data: TypeParameterResolver): ValidatedNel<HookValidationError, HookInfo> =
+            TODO("Not yet implemented")
+    }
+
+    private inner class HookFileVisitor : KSVisitorVoid() {
+        override fun visitFile(file: KSFile, data: Unit) {
+            val hookContainers = file.declarations.filter {
+                it is KSClassDeclaration
+            }.flatMap {
+                it.accept(HookContainerVisitor(), Unit)
+            }.mapNotNull { v ->
+                v.valueOr { errors ->
+                    errors.forEach { error -> logger.error(error.message, error.symbol) }
+                    null
+                }
+            }.toList()
+
+            if(hookContainers.isEmpty()) return
+            val packageName = file.packageName.asString()
+            val name = file.fileName.split(".").first()
+
+            generateFile(packageName, "${name}Hooks", hookContainers).writeTo(codeGenerator, aggregating = false)
+        }
+    }
+
+    private inner class HookContainerVisitor : KSDefaultVisitor<Unit, List<ValidatedNel<HookValidationError, HooksContainer>>>() {
+        override fun visitClassDeclaration(classDeclaration: KSClassDeclaration, data: Unit): List<ValidatedNel<HookValidationError, HooksContainer>> {
             val superTypeNames = classDeclaration.superTypes
                 .map(KSTypeReference::element)
                 .filterIsInstance<KSClassifierReference>()
                 .map(KSClassifierReference::referencedName)
 
             // TODO: Account for import aliases :P + how to avoid false positives? probably through resolve
-            if (!superTypeNames.contains("Hooks") && !superTypeNames.contains("HooksDsl")) {
-                classDeclaration.declarations.filter {
-                    it is KSClassDeclaration && it.validate()
-                }.forEach {
-                    it.accept(this, Unit)
-                }
+            return if (!superTypeNames.contains("Hooks") && !superTypeNames.contains("HooksDsl")) {
+                classDeclaration.declarations
+                    .filter { it is KSClassDeclaration && it.validate() }
+                    .flatMap { it.accept(this, Unit) }
+                    .toList()
             } else {
-                classDeclaration.findHooks()
+                val parentResolver = classDeclaration.typeParameters.toTypeParameterResolver()
+
+                classDeclaration.getAllProperties()
+                    .map { it.accept(HookPropertyVisitor(), parentResolver) }
+                    .sequence(Semigroup.nonEmptyList())
                     .map { hooks -> createHooksContainer(classDeclaration, hooks) }
-                    .map { hooksContainer ->
-                        if (hooksContainer.hooks.isEmpty()) return@map
-                        // TODO: somehow specify the original file as a dependency of this new file
-                        hooksContainer.generateFile().writeTo(codeGenerator, aggregating = false)
-                    }.valueOr { errors ->
-                        errors.forEach { logger.error(it.message, it.symbol) }
-                    }
+                    .let(::listOf)
             }
         }
-    }
 
-    internal fun createHooksContainer(classDeclaration: KSClassDeclaration, hooks: List<HookInfo>): HooksContainer {
-        val name =
-            "${classDeclaration.parentDeclaration?.simpleName?.asString() ?: ""}${classDeclaration.simpleName.asString()}Impl"
-        val resolvedPackageName = classDeclaration.packageName.asString().takeIf(String::isNotEmpty)
-        val visibilityModifier = classDeclaration.getVisibility().toKModifier() ?: KModifier.PUBLIC
-        val typeArguments = classDeclaration.typeParameters.map { it.toTypeVariableName() }
-        val className = classDeclaration.toClassName()
-        val typeSpecKind = classDeclaration.classKind.toTypeSpecKind()
-
-        return HooksContainer(
-            name,
-            className,
-            typeSpecKind,
-            resolvedPackageName,
-            visibilityModifier,
-            typeArguments,
-            hooks
-        )
-    }
-
-    private fun KSClassDeclaration.findHooks() = getAllProperties()
-        .filter {
-            // Only process properties that are abstract b/c that's what we need for a concrete class
-            it.modifiers.contains(Modifier.ABSTRACT)
+        fun ClassKind.toTypeSpecKind(): TypeSpec.Kind = when (this) {
+            ClassKind.CLASS -> TypeSpec.Kind.CLASS
+            ClassKind.INTERFACE -> TypeSpec.Kind.INTERFACE
+            ClassKind.OBJECT -> TypeSpec.Kind.OBJECT
+            else -> throw NotImplementedError("Hooks in constructs other than class, interface, and object aren't supported")
         }
-        .map(::validateProperty)
-        .sequence(Semigroup.nonEmptyList())
+
+        fun createHooksContainer(classDeclaration: KSClassDeclaration, hooks: List<HookInfo>): HooksContainer {
+            val name =
+                "${classDeclaration.parentDeclaration?.simpleName?.asString() ?: ""}${classDeclaration.simpleName.asString()}Impl"
+            val visibilityModifier = classDeclaration.getVisibility().toKModifier() ?: KModifier.PUBLIC
+            val typeArguments = classDeclaration.typeParameters.map { it.toTypeVariableName() }
+            val className = classDeclaration.toClassName()
+            val typeSpecKind = classDeclaration.classKind.toTypeSpecKind()
+
+            return HooksContainer(
+                name,
+                className,
+                typeSpecKind,
+                visibilityModifier,
+                typeArguments,
+                hooks
+            )
+        }
+
+        override fun defaultHandler(node: KSNode, data: Unit): List<ValidatedNel<HookValidationError, HooksContainer>> =
+            TODO("Not yet implemented")
+    }
+
 
     public class Provider : SymbolProcessorProvider {
         override fun create(environment: SymbolProcessorEnvironment): HooksProcessor = HooksProcessor(
@@ -99,11 +121,4 @@ public class HooksProcessor(
     }
 
     public class Exception(message: String, cause: Throwable? = null) : kotlin.Exception(message, cause)
-}
-
-internal fun ClassKind.toTypeSpecKind(): TypeSpec.Kind = when (this) {
-    ClassKind.CLASS -> TypeSpec.Kind.CLASS
-    ClassKind.INTERFACE -> TypeSpec.Kind.INTERFACE
-    ClassKind.OBJECT -> TypeSpec.Kind.OBJECT
-    else -> throw NotImplementedError("Hooks in constructs other than class, interface, and object aren't supported")
 }

--- a/processor/src/main/kotlin/com/intuit/hooks/plugin/ksp/validation/AnnotationValidations.kt
+++ b/processor/src/main/kotlin/com/intuit/hooks/plugin/ksp/validation/AnnotationValidations.kt
@@ -14,7 +14,6 @@ import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.ksp.TypeParameterResolver
 import com.squareup.kotlinpoet.ksp.toKModifier
 import com.squareup.kotlinpoet.ksp.toTypeName
-import com.squareup.kotlinpoet.ksp.toTypeParameterResolver
 
 /** Wrapper for [KSAnnotation] when we're sure that the annotation is a hook annotation */
 @JvmInline internal value class HookAnnotation(val symbol: KSAnnotation) {
@@ -49,7 +48,7 @@ internal fun KSPropertyDeclaration.validateHookAnnotation(parentResolver: TypePa
 
 private fun KSPropertyDeclaration.onlyHasASingleDslAnnotation(): ValidatedNel<HookValidationError, HookAnnotation> {
     val annotations = annotations.filter { it.shortName.asString() in annotationDslMarkers }.toList()
-    return when(annotations.size) {
+    return when (annotations.size) {
         0 -> HookValidationError.NoHookDslAnnotations(this).invalidNel()
         1 -> annotations.single().let(::HookAnnotation).valid()
         else -> HookValidationError.TooManyHookDslAnnotations(annotations, this).invalidNel()

--- a/processor/src/main/kotlin/com/intuit/hooks/plugin/ksp/validation/AnnotationValidations.kt
+++ b/processor/src/main/kotlin/com/intuit/hooks/plugin/ksp/validation/AnnotationValidations.kt
@@ -37,7 +37,6 @@ internal fun KSPropertyDeclaration.validateHookAnnotation(parentResolver: TypePa
         val mustBeHookType = mustBeHookType(annotation, parentResolver)
         val validateParameters = validateParameters(annotation, parentResolver)
         val hookMember = simpleName.asString()
-        // TODO: Should this actually default to public?
         val propertyVisibility = this.getVisibility().toKModifier() ?: KModifier.PUBLIC
 
         hasCodeGenerator.zip(

--- a/processor/src/main/kotlin/com/intuit/hooks/plugin/ksp/validation/HookValidations.kt
+++ b/processor/src/main/kotlin/com/intuit/hooks/plugin/ksp/validation/HookValidations.kt
@@ -3,8 +3,9 @@ package com.intuit.hooks.plugin.ksp.validation
 import arrow.core.*
 import com.google.devtools.ksp.symbol.*
 import com.intuit.hooks.plugin.codegen.HookInfo
-import com.intuit.hooks.plugin.codegen.HookType
 import com.intuit.hooks.plugin.ksp.text
+import com.squareup.kotlinpoet.ksp.TypeParameterResolver
+import com.squareup.kotlinpoet.ksp.toTypeParameterResolver
 
 // TODO: It'd be nice if the validations were codegen framework agnostic
 internal sealed class HookValidationError(val message: String, val symbol: KSNode) {
@@ -15,25 +16,22 @@ internal sealed class HookValidationError(val message: String, val symbol: KSNod
     class NoCodeGenerator(annotation: HookAnnotation) : HookValidationError("This hook plugin has no code generator for $annotation", annotation.symbol)
     class NoHookDslAnnotations(property: KSPropertyDeclaration) : HookValidationError("Hook property must be annotated with a DSL annotation", property)
     class TooManyHookDslAnnotations(annotations: List<KSAnnotation>, property: KSPropertyDeclaration) : HookValidationError("This hook has more than a single hook DSL annotation: $annotations", property)
-    class HookPropertyTypeMismatch(property: KSPropertyDeclaration, annotationType: String) : HookValidationError("Hook property type (${property.type.text}) does not match annotation hook type (@${annotationType.dropLast(4)})", property)
     class UnsupportedAbstractPropertyType(property: KSPropertyDeclaration) : HookValidationError("Abstract property type (${property.type.text}) not supported. Hook properties must be of type com.intuit.hooks.Hook", property)
+    class NotAnAbstractProperty(property: KSPropertyDeclaration) : HookValidationError("Hooks can only be abstract properties", property)
 }
 
 /** main entrypoint for validating [KSPropertyDeclaration]s as valid annotated hook members */
-internal fun validateProperty(property: KSPropertyDeclaration): ValidatedNel<HookValidationError, HookInfo> = with(property) {
+internal fun validateProperty(property: KSPropertyDeclaration, parentResolver: TypeParameterResolver): ValidatedNel<HookValidationError, HookInfo> = with(property) {
     // validate property has the correct type
     validateHookType()
-        .andThen { validateHookAnnotation() }
+        .andThen { validateHookAnnotation(parentResolver) }
         // validate property against hook info with specific hook type validations
         .andThen { info -> validateHookProperties(info) }
 }
 
-private fun KSPropertyDeclaration.validateHookType(): ValidatedNel<HookValidationError, KSTypeReference> = try {
+private fun KSPropertyDeclaration.validateHookType(): ValidatedNel<HookValidationError, KSTypeReference> =
     if (type.text == "Hook") type.valid()
     else HookValidationError.UnsupportedAbstractPropertyType(this).invalidNel()
-} catch (e: Exception) {
-    HookValidationError.UnsupportedAbstractPropertyType(this).invalidNel()
-}
 
 private fun KSPropertyDeclaration.validateHookProperties(hookInfo: HookInfo) =
     hookInfo.hookType.properties.map { it.validate(hookInfo, this) }

--- a/processor/src/main/kotlin/com/intuit/hooks/plugin/ksp/validation/HookValidations.kt
+++ b/processor/src/main/kotlin/com/intuit/hooks/plugin/ksp/validation/HookValidations.kt
@@ -5,7 +5,6 @@ import com.google.devtools.ksp.symbol.*
 import com.intuit.hooks.plugin.codegen.HookInfo
 import com.intuit.hooks.plugin.ksp.text
 import com.squareup.kotlinpoet.ksp.TypeParameterResolver
-import com.squareup.kotlinpoet.ksp.toTypeParameterResolver
 
 // TODO: It'd be nice if the validations were codegen framework agnostic
 internal sealed class HookValidationError(val message: String, val symbol: KSNode) {

--- a/processor/src/test/kotlin/com/intuit/hooks/plugin/HookValidationErrors.kt
+++ b/processor/src/test/kotlin/com/intuit/hooks/plugin/HookValidationErrors.kt
@@ -10,7 +10,7 @@ class HookValidationErrors {
         val testHooks = SourceFile.kotlin(
             "TestHooks.kt",
             """
-            import com.intuit.hooks.SyncHook
+            import com.intuit.hooks.Hook
             import com.intuit.hooks.dsl.Hooks
             
             internal abstract class TestHooks : Hooks() {
@@ -28,18 +28,18 @@ class HookValidationErrors {
         val testHooks = SourceFile.kotlin(
             "TestHooks.kt",
             """
-            import com.intuit.hooks.SyncHook
+            import com.intuit.hooks.Hook
             import com.intuit.hooks.dsl.Hooks
             
             internal abstract class TestHooks : Hooks() {
-                abstract val syncHook: SyncHook<*>
+                abstract val syncHook: Hook
             }
             """
         )
 
         val (_, result) = compile(testHooks)
         result.assertOk()
-        result.assertContainsMessages("Hook property must be annotated with respective DSL annotation for SyncHook<*>")
+        result.assertContainsMessages("Hook property must be annotated with a DSL annotation")
     }
 
     @Test fun `hook property has too many hook annotations`() {
@@ -47,13 +47,13 @@ class HookValidationErrors {
             "TestHooks.kt",
             """
             import com.intuit.hooks.BailResult
-            import com.intuit.hooks.SyncHook
+            import com.intuit.hooks.Hook
             import com.intuit.hooks.dsl.Hooks
             
             internal abstract class TestHooks : Hooks() {
                 @Sync<() -> Unit>
                 @SyncBail<() -> BailResult<Int>>
-                abstract val syncHook: SyncHook<*>
+                abstract val syncHook: Hook
             }
             """
         )
@@ -63,36 +63,16 @@ class HookValidationErrors {
         result.assertContainsMessages("This hook has more than a single hook DSL annotation: [@Sync, @SyncBail]")
     }
 
-    @Test fun `hook property type does not match annotation`() {
-        val testHooks = SourceFile.kotlin(
-            "TestHooks.kt",
-            """
-            import com.intuit.hooks.BailResult
-            import com.intuit.hooks.SyncHook
-            import com.intuit.hooks.dsl.Hooks
-            
-            internal abstract class TestHooks : Hooks() {
-                @SyncBail<() -> BailResult<Int>>
-                abstract val syncHook: SyncHook<*>
-            }
-            """
-        )
-
-        val (_, result) = compile(testHooks)
-        result.assertOk()
-        result.assertContainsMessages("Hook property type (SyncHook<*>) does not match annotation hook type (@SyncBail")
-    }
-
     @Test fun `async hooks must has suspend modifier`() {
         val testHooks = SourceFile.kotlin(
             "TestHooks.kt",
             """
-            import com.intuit.hooks.AsyncSeriesHook
+            import com.intuit.hooks.Hook
             import com.intuit.hooks.dsl.Hooks
             
             internal abstract class TestHooks : Hooks() {
                 @AsyncSeries<() -> Unit>
-                abstract val syncHook: AsyncSeriesHook<*>
+                abstract val syncHook: Hook
             }
             """
         )
@@ -106,12 +86,12 @@ class HookValidationErrors {
         val testHooks = SourceFile.kotlin(
             "TestHooks.kt",
             """
-            import com.intuit.hooks.SyncWaterfallHook
+            import com.intuit.hooks.Hook
             import com.intuit.hooks.dsl.Hooks
             
             internal abstract class TestHooks : Hooks() {
                 @SyncWaterfall<() -> String>
-                abstract val syncHook: SyncWaterfallHook<*, *>
+                abstract val syncHook: Hook
             }
             """
         )
@@ -125,12 +105,12 @@ class HookValidationErrors {
         val testHooks = SourceFile.kotlin(
             "TestHooks.kt",
             """
-            import com.intuit.hooks.SyncWaterfallHook
+            import com.intuit.hooks.Hook
             import com.intuit.hooks.dsl.Hooks
             
             internal abstract class TestHooks : Hooks() {
                 @SyncWaterfall<(Int, Int) -> Unit>
-                abstract val syncHook: SyncWaterfallHook<*, *>
+                abstract val syncHook: Hook
             }
             """
         )
@@ -144,12 +124,12 @@ class HookValidationErrors {
         val testHooks = SourceFile.kotlin(
             "TestHooks.kt",
             """
-            import com.intuit.hooks.AsyncSeriesBailHook
+            import com.intuit.hooks.Hook
             import com.intuit.hooks.dsl.Hooks
             
             internal abstract class TestHooks : Hooks() {
                 @AsyncSeriesWaterfall<() -> String>
-                abstract val realBad: AsyncSeriesBailHook<*, *>
+                abstract val realBad: Hook
                 abstract val state: Int
             }
             """
@@ -158,7 +138,6 @@ class HookValidationErrors {
         val (_, result) = compile(testHooks)
         result.assertOk()
         result.assertContainsMessages(
-            "Hook property type (AsyncSeriesBailHook<*, *>) does not match annotation hook type (@AsyncSeriesWaterfall)",
             "Async hooks must be defined with a suspend function signature",
             "Waterfall hooks must take at least one parameter",
             "Waterfall hooks must specify the same types for the first parameter and the return type",

--- a/processor/src/test/kotlin/com/intuit/hooks/plugin/HooksProcessorTest.kt
+++ b/processor/src/test/kotlin/com/intuit/hooks/plugin/HooksProcessorTest.kt
@@ -9,12 +9,12 @@ class HooksProcessorTest {
         val testHooks = SourceFile.kotlin(
             "TestHooks.kt",
             """
-            import com.intuit.hooks.SyncHook
             import com.intuit.hooks.dsl.Hooks
+            import com.intuit.hooks.Hook
             
             internal abstract class TestHooks : Hooks() {
                 @Sync<(String) -> Unit>
-                abstract val testSyncHook: SyncHook<*>
+                abstract val testSyncHook: Hook
             }
             """
         )
@@ -46,12 +46,12 @@ class HooksProcessorTest {
             """
             package com.intuit.hooks.test
 
-            import com.intuit.hooks.SyncHook
+            import com.intuit.hooks.Hook
             import com.intuit.hooks.dsl.Hooks
             
             internal abstract class TestHooks : Hooks() {
                 @Sync<(String) -> Unit>
-                abstract val testSyncHook: SyncHook<*>
+                abstract val testSyncHook: Hook
             }
             """
         )
@@ -65,12 +65,12 @@ class HooksProcessorTest {
         val testHooks = SourceFile.kotlin(
             "TestHooks.kt",
             """
-            import com.intuit.hooks.SyncHook
+            import com.intuit.hooks.Hook
             import com.intuit.hooks.dsl.Hooks
             
             internal abstract class TestHooks : Hooks() {
                 @Sync<(Map<List<Int>, List<String>>) -> Unit>
-                abstract val testSyncHook: SyncHook<*>
+                abstract val testSyncHook: Hook
             }
         """
         )
@@ -101,12 +101,12 @@ class HooksProcessorTest {
         val testHooks = SourceFile.kotlin(
             "TestHooks.kt",
             """
-            import com.intuit.hooks.AsyncSeriesWaterfallHook
+            import com.intuit.hooks.Hook
             import com.intuit.hooks.dsl.Hooks
             
             internal abstract class TestHooks : Hooks() {
                 @AsyncSeriesWaterfall<suspend (String) -> String>
-                abstract val testAsyncSeriesWaterfallHook: AsyncSeriesWaterfallHook<*, *>
+                abstract val testAsyncSeriesWaterfallHook: Hook
             }
         """
         )
@@ -147,17 +147,17 @@ class HooksProcessorTest {
             import kotlinx.coroutines.ExperimentalCoroutinesApi
             
             internal abstract class TestHooks : Hooks() {
-                @Sync<(newSpeed: Int) -> Unit> abstract val sync: SyncHook<*>
-                @SyncBail<(Boolean) -> BailResult<Int>> abstract val syncBail: SyncBailHook<*, *>
-                @SyncLoop<(foo: Boolean) -> LoopResult> abstract val syncLoop: SyncLoopHook<*, *>
-                @SyncWaterfall<(name: String) -> String> abstract val syncWaterfall: SyncWaterfallHook<*, *>
+                @Sync<(newSpeed: Int) -> Unit> abstract val sync: Hook
+                @SyncBail<(Boolean) -> BailResult<Int>> abstract val syncBail: Hook
+                @SyncLoop<(foo: Boolean) -> LoopResult> abstract val syncLoop: Hook
+                @SyncWaterfall<(name: String) -> String> abstract val syncWaterfall: Hook
                 @ExperimentalCoroutinesApi
-                @AsyncParallelBail<suspend (String) -> BailResult<String>> abstract val asyncParallelBail: AsyncParallelBailHook<*, *>
-                @AsyncParallel<suspend (String) -> Int> abstract val asyncParallel: AsyncParallelHook<*>
-                @AsyncSeries<suspend (String) -> Int> abstract val asyncSeries: AsyncSeriesHook<*>
-                @AsyncSeriesBail<suspend (String) -> BailResult<String>> abstract val asyncSeriesBail: AsyncSeriesBailHook<*, *>
-                @AsyncSeriesLoop<suspend (String) -> LoopResult> abstract val asyncSeriesLoop: AsyncSeriesLoopHook<*, *>
-                @AsyncSeriesWaterfall<suspend (String) -> String> abstract val asyncSeriesWaterfall: AsyncSeriesWaterfallHook<*, *>
+                @AsyncParallelBail<suspend (String) -> BailResult<String>> abstract val asyncParallelBail: Hook
+                @AsyncParallel<suspend (String) -> Int> abstract val asyncParallel: Hook
+                @AsyncSeries<suspend (String) -> Int> abstract val asyncSeries: Hook
+                @AsyncSeriesBail<suspend (String) -> BailResult<String>> abstract val asyncSeriesBail: Hook
+                @AsyncSeriesLoop<suspend (String) -> LoopResult> abstract val asyncSeriesLoop: Hook
+                @AsyncSeriesWaterfall<suspend (String) -> String> abstract val asyncSeriesWaterfall: Hook
             }
             """
         )
@@ -171,12 +171,12 @@ class HooksProcessorTest {
         val testHooks = SourceFile.kotlin(
             "TestHooks.kt",
             """
-            import com.intuit.hooks.SyncHook
+            import com.intuit.hooks.Hook
             import com.intuit.hooks.dsl.Hooks
             
             internal abstract class TestHooks<T, U> : Hooks() {
                 @Sync<(T) -> U>
-                abstract val testSyncHook: SyncHook<*>
+                abstract val testSyncHook: Hook
             }
             """
         )
@@ -207,13 +207,13 @@ class HooksProcessorTest {
         val testHooks = SourceFile.kotlin(
             "TestHooks.kt",
             """
-            import com.intuit.hooks.SyncHook
+            import com.intuit.hooks.Hook
             import com.intuit.hooks.dsl.HooksDsl
             
             class Controller {
                 abstract class Hooks : HooksDsl() {
                     @Sync<(String) -> Unit>
-                    abstract val testSyncHook: SyncHook<*>
+                    abstract val testSyncHook: Hook
                 }
 
                 val hooks = ControllerHooksImpl()

--- a/processor/src/test/kotlin/com/intuit/hooks/plugin/HooksProcessorTest.kt
+++ b/processor/src/test/kotlin/com/intuit/hooks/plugin/HooksProcessorTest.kt
@@ -5,6 +5,46 @@ import org.junit.jupiter.api.Test
 
 class HooksProcessorTest {
 
+    @Test fun `multiple hook classes in a single file`() {
+        val testHooks = SourceFile.kotlin(
+            "TestHooks.kt",
+            """
+            import com.intuit.hooks.dsl.Hooks
+            import com.intuit.hooks.Hook
+            
+            internal abstract class TestHooks : Hooks() {
+                @Sync<(String) -> Unit>
+                abstract val testSyncHook: Hook
+            }
+
+            internal abstract class AnotherHookClass : Hooks() {
+                @Sync<(String) -> Unit>
+                abstract val testSyncHook: Hook
+            }
+            """
+        )
+
+        val assertions = SourceFile.kotlin(
+            "Assertions.kt",
+            """
+            import org.junit.jupiter.api.Assertions.*
+
+            fun testHook() {
+                var tapCalled = false
+                val hooks = TestHooksImpl()
+                val another = AnotherHookClassImpl()
+                hooks.testSyncHook.tap("test") { _, x -> tapCalled = true }
+                hooks.testSyncHook.call("hello")
+                assertTrue(tapCalled)
+            }
+            """
+        )
+
+        val (compilation, result) = compile(testHooks, assertions)
+        result.assertOk()
+        compilation.assertKspGeneratedSources("TestHooksHooks.kt")
+        result.runCompiledAssertions()
+    }
     @Test fun `generates simple sync hook`() {
         val testHooks = SourceFile.kotlin(
             "TestHooks.kt",
@@ -36,7 +76,7 @@ class HooksProcessorTest {
 
         val (compilation, result) = compile(testHooks, assertions)
         result.assertOk()
-        compilation.assertKspGeneratedSources("TestHooksImpl.kt")
+        compilation.assertKspGeneratedSources("TestHooksHooks.kt")
         result.runCompiledAssertions()
     }
 
@@ -58,7 +98,7 @@ class HooksProcessorTest {
 
         val (compilation, result) = compile(testHooks)
         result.assertOk()
-        compilation.assertKspGeneratedSources("com.intuit.hooks.test.TestHooksImpl.kt")
+        compilation.assertKspGeneratedSources("com.intuit.hooks.test.TestHooksHooks.kt")
     }
 
     @Test fun `generates hook with nested generic type params`() {
@@ -93,7 +133,7 @@ class HooksProcessorTest {
 
         val (compilation, result) = compile(testHooks, assertions)
         result.assertOk()
-        compilation.assertKspGeneratedSources("TestHooksImpl.kt")
+        compilation.assertKspGeneratedSources("TestHooksHooks.kt")
         result.runCompiledAssertions()
     }
 
@@ -134,7 +174,7 @@ class HooksProcessorTest {
 
         val (compilation, result) = compile(testHooks, assertions)
         result.assertOk()
-        compilation.assertKspGeneratedSources("TestHooksImpl.kt")
+        compilation.assertKspGeneratedSources("TestHooksHooks.kt")
         result.runCompiledAssertions()
     }
 
@@ -164,7 +204,7 @@ class HooksProcessorTest {
 
         val (compilation, result) = compile(testHooks)
         result.assertOk()
-        compilation.assertKspGeneratedSources("TestHooksImpl.kt")
+        compilation.assertKspGeneratedSources("TestHooksHooks.kt")
     }
 
     @Test fun `generates generic hook class`() {
@@ -199,7 +239,7 @@ class HooksProcessorTest {
 
         val (compilation, result) = compile(testHooks, assertions)
         result.assertOk()
-        compilation.assertKspGeneratedSources("TestHooksImpl.kt")
+        compilation.assertKspGeneratedSources("TestHooksHooks.kt")
         result.runCompiledAssertions()
     }
 
@@ -239,7 +279,7 @@ class HooksProcessorTest {
 
         val (compilation, result) = compile(testHooks, assertions)
         result.assertOk()
-        compilation.assertKspGeneratedSources("ControllerHooksImpl.kt")
+        compilation.assertKspGeneratedSources("TestHooksHooks.kt")
         result.runCompiledAssertions()
     }
 }

--- a/processor/src/test/kotlin/com/intuit/hooks/plugin/KotlinCompilation.kt
+++ b/processor/src/test/kotlin/com/intuit/hooks/plugin/KotlinCompilation.kt
@@ -48,6 +48,12 @@ fun KotlinCompilation.Result.assertContainsMessages(vararg messages: String) {
     }
 }
 
+fun KotlinCompilation.Result.assertNoKspErrors() {
+    Assertions.assertFalse(this.messages.contains("e: [ksp]")) {
+        "Compilation result had a KSP error"
+    }
+}
+
 /** Perform compilation on the [sources], utilizing the default configuration for the [HooksProcessor], if not explicitly configured */
 fun compile(
     vararg sources: SourceFile,


### PR DESCRIPTION
<!-- PR Template
Thank you for contributing! Please read through the following **before** opening your PR.
* Verify you have read the Contribution Guidelines on the ./CONTRIBUTING.md document
-->

# What Changed

⚠️ Merge after #28 

This PR introduces the empty `Hook` sealed class, which is the ultimate super type of all Hooks. The processor can look for this and use all the type information from the annotation instead of requiring the user to specify the type of hook twice, once in the annotation and once in the type signature. The downside to this is that the original type won't have any type information.

## Why

Todo:

- [x] Add tests
- [x] Add docs
- [x] Add release notes

# Release Notes

💥 **Breaking Change** 💥 

Relax typing specification when using the DSL. Hooks should always use the `Hook` superclass as the specified type and rely solely on the annotation to specify the actual constraints of the hook:

```kotlin
abstract class CarHooks : Hooks() {
    @Sync<() -> Unit>
    abstract val brake: Hook
    
    @Sync<(newSpeed: Int) -> Unit>
    abstract val accelerate: Hook
}
```

<!-- GITHUB_RELEASE PR BODY: canary-version -->
📦 Published PR as canary version: <code>0.12.2-canary.29.311-SNAPSHOT</code>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
