### PR TITLE
BailHook default handler

### DIFF
--- a/hooks/api/hooks.api
+++ b/hooks/api/hooks.api
@@ -16,7 +16,8 @@ public abstract class com/intuit/hooks/AsyncParallelHook : com/intuit/hooks/Asyn
 
 public abstract class com/intuit/hooks/AsyncSeriesBailHook : com/intuit/hooks/AsyncBaseHook {
 	public fun <init> ()V
-	protected final fun call (Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	protected final fun call (Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun call$default (Lcom/intuit/hooks/AsyncSeriesBailHook;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public abstract class com/intuit/hooks/AsyncSeriesHook : com/intuit/hooks/AsyncBaseHook {
@@ -97,7 +98,8 @@ public final class com/intuit/hooks/LoopResult$Companion {
 
 public abstract class com/intuit/hooks/SyncBailHook : com/intuit/hooks/SyncBaseHook {
 	public fun <init> ()V
-	protected final fun call (Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
+	protected final fun call (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static synthetic fun call$default (Lcom/intuit/hooks/SyncBailHook;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public abstract class com/intuit/hooks/SyncBaseHook : com/intuit/hooks/BaseHook {

--- a/hooks/src/main/kotlin/com/intuit/hooks/AsyncSeriesBailHook.kt
+++ b/hooks/src/main/kotlin/com/intuit/hooks/AsyncSeriesBailHook.kt
@@ -1,15 +1,16 @@
 package com.intuit.hooks
 
 public abstract class AsyncSeriesBailHook<F : Function<BailResult<R>>, R> : AsyncBaseHook<F>("AsyncSeriesBailHook") {
-    protected suspend fun call(invokeWithContext: suspend (F, HookContext) -> BailResult<R>): R? {
+    protected suspend fun call(invokeWithContext: suspend (F, HookContext) -> BailResult<R>, default: (suspend (HookContext) -> R)? = null): R? {
         val context = setup(invokeWithContext)
 
         taps.forEach { tapInfo ->
             when (val result = invokeWithContext(tapInfo.f, context)) {
                 is BailResult.Bail<R> -> return@call result.value
+                is BailResult.Continue -> {}
             }
         }
 
-        return null
+        return default?.invoke(context)
     }
 }

--- a/hooks/src/main/kotlin/com/intuit/hooks/SyncBailHook.kt
+++ b/hooks/src/main/kotlin/com/intuit/hooks/SyncBailHook.kt
@@ -6,20 +6,18 @@ public sealed class BailResult<T> {
     public class Continue<T> : BailResult<T>()
 }
 
-public abstract class SyncBailHook<F : Function<BailResult<R>>, R> : SyncBaseHook<F>("SyncBailHook") {
-    protected fun call(invokeWithContext: (F, HookContext) -> BailResult<R>, default: ((R) -> Unit)? = null): R? {
+public abstract class SyncBailHook<T, F : (HookContext, T) -> BailResult<R>, R> : SyncBaseHook<F>("SyncBailHook") {
+    protected fun call(invokeWithContext: (F, HookContext) -> BailResult<R>, default: ((T) -> Unit)? = null, p1: T): R? {
         val context = setup(invokeWithContext)
 
         taps.forEach { tapInfo ->
             when (val result = invokeWithContext(tapInfo.f, context)) {
-                is BailResult.Bail<R> -> {
-                    default?.invoke(result.value)
-                    return@call result.value
-                }
+                is BailResult.Bail<R> -> return@call result.value
                 is BailResult.Continue -> {}
             }
         }
 
+        default?.invoke(p1)
         return null
     }
 }

--- a/hooks/src/main/kotlin/com/intuit/hooks/SyncBailHook.kt
+++ b/hooks/src/main/kotlin/com/intuit/hooks/SyncBailHook.kt
@@ -7,7 +7,7 @@ public sealed class BailResult<T> {
 }
 
 public abstract class SyncBailHook<F : Function<BailResult<R>>, R> : SyncBaseHook<F>("SyncBailHook") {
-    protected fun call(invokeWithContext: (F, HookContext) -> BailResult<R>, default: (() -> R)? = null): R? {
+    protected fun call(invokeWithContext: (F, HookContext) -> BailResult<R>, default: ((HookContext) -> R)? = null): R? {
         val context = setup(invokeWithContext)
 
         taps.forEach { tapInfo ->
@@ -17,6 +17,6 @@ public abstract class SyncBailHook<F : Function<BailResult<R>>, R> : SyncBaseHoo
             }
         }
 
-        return default?.invoke()
+        return default?.invoke(context)
     }
 }

--- a/hooks/src/main/kotlin/com/intuit/hooks/SyncBailHook.kt
+++ b/hooks/src/main/kotlin/com/intuit/hooks/SyncBailHook.kt
@@ -6,8 +6,8 @@ public sealed class BailResult<T> {
     public class Continue<T> : BailResult<T>()
 }
 
-public abstract class SyncBailHook<T, F : (HookContext, T) -> BailResult<R>, R> : SyncBaseHook<F>("SyncBailHook") {
-    protected fun call(invokeWithContext: (F, HookContext) -> BailResult<R>, default: ((T) -> Unit)? = null, p1: T): R? {
+public abstract class SyncBailHook<F : Function<BailResult<R>>, R> : SyncBaseHook<F>("SyncBailHook") {
+    protected fun call(invokeWithContext: (F, HookContext) -> BailResult<R>, default: (() -> R)? = null): R? {
         val context = setup(invokeWithContext)
 
         taps.forEach { tapInfo ->
@@ -17,7 +17,6 @@ public abstract class SyncBailHook<T, F : (HookContext, T) -> BailResult<R>, R> 
             }
         }
 
-        default?.invoke(p1)
-        return null
+        return default?.invoke()
     }
 }

--- a/hooks/src/main/kotlin/com/intuit/hooks/dsl/Hooks.kt
+++ b/hooks/src/main/kotlin/com/intuit/hooks/dsl/Hooks.kt
@@ -24,7 +24,7 @@ public abstract class Hooks {
         ReplaceWith("@Hooks.SyncBail<F>"),
         DeprecationLevel.ERROR,
     )
-    protected fun <F : Function<BailResult<*>>> syncBailHook(): SyncBailHook<*, *, *> = stub()
+    protected fun <F : Function<BailResult<*>>> syncBailHook(): SyncBailHook<*, *> = stub()
 
     protected annotation class SyncWaterfall<F : Function<*>>
 

--- a/hooks/src/main/kotlin/com/intuit/hooks/dsl/Hooks.kt
+++ b/hooks/src/main/kotlin/com/intuit/hooks/dsl/Hooks.kt
@@ -24,7 +24,7 @@ public abstract class Hooks {
         ReplaceWith("@Hooks.SyncBail<F>"),
         DeprecationLevel.ERROR,
     )
-    protected fun <F : Function<BailResult<*>>> syncBailHook(): SyncBailHook<*, *> = stub()
+    protected fun <F : Function<BailResult<*>>> syncBailHook(): SyncBailHook<*, *, *> = stub()
 
     protected annotation class SyncWaterfall<F : Function<*>>
 

--- a/hooks/src/test/kotlin/com/intuit/hooks/AsyncSeriesBailHookTests.kt
+++ b/hooks/src/test/kotlin/com/intuit/hooks/AsyncSeriesBailHookTests.kt
@@ -7,7 +7,16 @@ import org.junit.jupiter.api.Test
 
 class AsyncSeriesBailHookTests {
     class Hook1<T1, R : Any?> : AsyncSeriesBailHook<suspend (HookContext, T1) -> BailResult<R>, R>() {
-        suspend fun call(p1: T1): R? = super.call { f, context -> f(context, p1) }
+        suspend fun call(p1: T1, default: (suspend (HookContext, T1) -> R)? = null): R? = super.call(
+            { f, context -> f(context, p1) },
+            default?.let {
+                { context -> default(context, p1) }
+            }
+        )
+
+        suspend fun call(p1: T1, default: (suspend (T1) -> R)) = call(p1) { _, arg1 ->
+            default.invoke(arg1)
+        }
     }
 
     @Test
@@ -41,12 +50,37 @@ class AsyncSeriesBailHookTests {
     }
 
     @Test
-    fun `bail taps can bail without return value`() {
-        val h = SyncBailHookTests.Hook1<String, Unit>()
+    fun `bail taps can bail without return value`() = runBlocking {
+        val h = Hook1<String, Unit>()
         h.tap("continue") { _, _ -> BailResult.Continue() }
         h.tap("bail") { _, _ -> BailResult.Bail(Unit) }
         h.tap("continue again") { _, _ -> Assertions.fail("Should never have gotten here!") }
 
         Assertions.assertEquals(Unit, h.call("David"))
+    }
+
+    @Test
+    fun `bail call with default handler invokes without taps bailing`() = runBlocking {
+        val h = Hook1<String, String>()
+        h.tap("continue") { _, _ -> BailResult.Continue() }
+        h.tap("continue again") { _, _ -> BailResult.Continue() }
+
+        val result = h.call("David") { _, str ->
+            str
+        }
+
+        Assertions.assertEquals("David", result)
+    }
+
+    @Test
+    fun `bail call with default handler does not invoke with bail`() = runBlocking {
+        val h = Hook1<String, String>()
+        h.tap("continue") { _, _ -> BailResult.Continue() }
+        h.tap("bail") { _, _ -> BailResult.Bail("bailing") }
+        h.tap("continue again") { _, _ -> Assertions.fail("Should never have gotten here!") }
+
+        val result = h.call("David") { str -> str }
+
+        Assertions.assertEquals("bailing", result)
     }
 }

--- a/hooks/src/test/kotlin/com/intuit/hooks/SyncBailHookTests.kt
+++ b/hooks/src/test/kotlin/com/intuit/hooks/SyncBailHookTests.kt
@@ -7,8 +7,8 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
 class SyncBailHookTests {
-    class Hook1<T1, R : Any?> : SyncBailHook<(HookContext, T1) -> BailResult<R>, R>() {
-        fun call(p1: T1, default: ((R) -> Unit)? = null) = super.call({ f, context -> f(context, p1) }, default)
+    class Hook1<T1, R : Any?> : SyncBailHook<T1, (HookContext, T1) -> BailResult<R>, R>() {
+        fun call(p1: T1, default: ((T1) -> Unit)? = null) = super.call({ f, context -> f(context, p1) }, default, p1)
     }
 
     @Test
@@ -53,25 +53,25 @@ class SyncBailHookTests {
     }
 
     @Test
-    fun `bail call with default handler invokes on bail`() {
+    fun `bail call with default handler invokes without taps bailing`() {
         val h = Hook1<String, String>()
         h.tap("continue") { _, _ -> BailResult.Continue() }
-        h.tap("bail") { _, _ -> BailResult.Bail("bailing") }
-        h.tap("continue again") { _, _ -> Assertions.fail("Should never have gotten here!") }
+        h.tap("continue again") { _, _ -> BailResult.Continue() }
 
         var bailResult: String? = null
         h.call("David") {
             bailResult = it
         }
 
-        Assertions.assertEquals("bailing", bailResult)
+        Assertions.assertEquals("David", bailResult)
     }
 
     @Test
-    fun `bail call with default handler does not invoke without bail`() {
+    fun `bail call with default handler does not invoke with bail`() {
         val h = Hook1<String, String>()
         h.tap("continue") { _, _ -> BailResult.Continue() }
-        h.tap("continue again") { _, _ -> BailResult.Continue() }
+        h.tap("bail") { _, _ -> BailResult.Bail("bailing") }
+        h.tap("continue again") { _, _ -> Assertions.fail("Should never have gotten here!") }
 
         var bailResult: String? = null
         h.call("David") {

--- a/processor/src/main/kotlin/com/intuit/hooks/plugin/codegen/Poet.kt
+++ b/processor/src/main/kotlin/com/intuit/hooks/plugin/codegen/Poet.kt
@@ -102,7 +102,7 @@ internal fun HookInfo.generateClass(): TypeSpec {
                     ).build()
                 )
                 .returns(hookSignature.nullableReturnTypeType)
-                .addStatement("return call ($paramsWithoutTypes) { _, arg1 -> default.invoke(arg1) }")
+                .addStatement("return call ($paramsWithoutTypes) { _, $paramsWithoutTypes -> default.invoke($paramsWithoutTypes) }")
 
             val contextCall = callBuilder
                 .addParameter(

--- a/processor/src/main/kotlin/com/intuit/hooks/plugin/codegen/Poet.kt
+++ b/processor/src/main/kotlin/com/intuit/hooks/plugin/codegen/Poet.kt
@@ -40,13 +40,14 @@ private fun HooksContainer.generateContainerClass(): TypeSpec {
     }.build()
 }
 
+internal val HookInfo.callBuilder get() = FunSpec.builder("call")
+    .addParameters(parameterSpecs)
+    .apply {
+        if (isAsync)
+            addModifiers(KModifier.SUSPEND)
+    }
+
 internal fun HookInfo.generateClass(): TypeSpec {
-    val callBuilder = FunSpec.builder("call")
-        .addParameters(parameterSpecs)
-        .apply {
-            if (this@generateClass.isAsync)
-                addModifiers(KModifier.SUSPEND)
-        }
 
     val (superclass, calls) = when (hookType) {
         HookType.SyncHook, HookType.AsyncSeriesHook, HookType.AsyncParallelHook -> {
@@ -90,12 +91,7 @@ internal fun HookInfo.generateClass(): TypeSpec {
             requireNotNull(hookSignature.nullableReturnTypeType)
             val superclass = createSuperClass(hookSignature.returnTypeType)
 
-            val call = FunSpec.builder("call")
-                .addParameters(parameterSpecs)
-                .apply {
-                    if (this@generateClass.isAsync)
-                        addModifiers(KModifier.SUSPEND)
-                }
+            val call = callBuilder
                 .addParameter(
                     ParameterSpec.builder(
                         "default",
@@ -108,12 +104,7 @@ internal fun HookInfo.generateClass(): TypeSpec {
                 .returns(hookSignature.nullableReturnTypeType)
                 .addStatement("return call ($paramsWithoutTypes) { _, arg1 -> default.invoke(arg1) }")
 
-            val call2 = FunSpec.builder("call")
-                .addParameters(parameterSpecs)
-                .apply {
-                    if (this@generateClass.isAsync)
-                        addModifiers(KModifier.SUSPEND)
-                }
+            val call2 = callBuilder
                 .addParameter(
                     ParameterSpec.builder(
                         "default",

--- a/processor/src/main/kotlin/com/intuit/hooks/plugin/codegen/Poet.kt
+++ b/processor/src/main/kotlin/com/intuit/hooks/plugin/codegen/Poet.kt
@@ -91,8 +91,17 @@ internal fun HookInfo.generateClass(): TypeSpec {
             val superclass = createSuperClass(hookSignature.returnTypeType)
 
             val call = callBuilder
+                .addParameter(
+                    ParameterSpec.builder(
+                        "default",
+                        LambdaTypeName.get(
+                            parameters = parameterSpecs,
+                            returnType = hookSignature.returnTypeType!!
+                        ).copy(nullable = true)
+                    ).defaultValue(CodeBlock.of("null")).build()
+                )
                 .returns(hookSignature.nullableReturnTypeType)
-                .addStatement("return super.call { f, context -> f(context, $paramsWithoutTypes) }")
+                .addStatement("return super.call ({ f, context -> f(context, $paramsWithoutTypes) }, default?.let { { default($paramsWithoutTypes) } } )")
 
             Pair(superclass, call)
         }

--- a/processor/src/main/kotlin/com/intuit/hooks/plugin/codegen/Poet.kt
+++ b/processor/src/main/kotlin/com/intuit/hooks/plugin/codegen/Poet.kt
@@ -108,7 +108,7 @@ internal fun HookInfo.generateClass(): TypeSpec {
                 .addParameter(
                     ParameterSpec.builder(
                         "default",
-                        createHookContextLambda(hookSignature.returnTypeType!!).copy(nullable = true)
+                        createHookContextLambda(hookSignature.returnTypeType).copy(nullable = true)
                     ).defaultValue(CodeBlock.of("null")).build()
                 )
                 .returns(hookSignature.nullableReturnTypeType)

--- a/processor/src/main/kotlin/com/intuit/hooks/plugin/codegen/Poet.kt
+++ b/processor/src/main/kotlin/com/intuit/hooks/plugin/codegen/Poet.kt
@@ -121,12 +121,13 @@ internal fun HookInfo.generateClass(): TypeSpec {
             requireNotNull(hookSignature.nullableReturnTypeType)
             val superclass = createSuperClass(hookSignature.returnTypeType)
 
-            // force the concurrency parameter to be first
-            callBuilder.parameters.add(0, ParameterSpec("concurrency", INT))
+            val call = with(callBuilder) {
+                // force the concurrency parameter to be first
+                parameters.add(0, ParameterSpec("concurrency", INT))
 
-            val call = callBuilder
-                .returns(hookSignature.nullableReturnTypeType)
-                .addStatement("return super.call(concurrency) { f, context -> f(context, $paramsWithoutTypes) }")
+                returns(hookSignature.nullableReturnTypeType)
+                    .addStatement("return super.call(concurrency) { f, context -> f(context, $paramsWithoutTypes) }")
+            }
 
             Pair(superclass, listOf(call))
         }

--- a/processor/src/main/kotlin/com/intuit/hooks/plugin/codegen/Poet.kt
+++ b/processor/src/main/kotlin/com/intuit/hooks/plugin/codegen/Poet.kt
@@ -104,7 +104,7 @@ internal fun HookInfo.generateClass(): TypeSpec {
                 .returns(hookSignature.nullableReturnTypeType)
                 .addStatement("return call ($paramsWithoutTypes) { _, arg1 -> default.invoke(arg1) }")
 
-            val call2 = callBuilder
+            val contextCall = callBuilder
                 .addParameter(
                     ParameterSpec.builder(
                         "default",
@@ -114,7 +114,7 @@ internal fun HookInfo.generateClass(): TypeSpec {
                 .returns(hookSignature.nullableReturnTypeType)
                 .addStatement("return super.call ({ f, context -> f(context, $paramsWithoutTypes) }, default?.let { { context -> default(context, $paramsWithoutTypes) } } )")
 
-            Pair(superclass, listOf(call, call2))
+            Pair(superclass, listOf(call, contextCall))
         }
         // parallel bail requires the concurrency parameter, otherwise it would be just like the other bail hooks
         HookType.AsyncParallelBailHook -> {

--- a/processor/src/test/kotlin/com/intuit/hooks/plugin/HooksProcessorTest.kt
+++ b/processor/src/test/kotlin/com/intuit/hooks/plugin/HooksProcessorTest.kt
@@ -306,7 +306,7 @@ class HooksProcessorTest {
             fun testHook() {
                 val hooks = TestBailHooksImpl()
                 hooks.testSyncBailHook.tap("test") { _, _ -> BailResult.Continue() }
-                val result = hooks.testSyncBailHook.call("hello") { str ->
+                val result = hooks.testSyncBailHook.call("hello") { ctx, str ->
                     str + " world"
                 }
                 assertEquals("hello world", result)

--- a/processor/src/test/kotlin/com/intuit/hooks/plugin/HooksProcessorTest.kt
+++ b/processor/src/test/kotlin/com/intuit/hooks/plugin/HooksProcessorTest.kt
@@ -282,6 +282,44 @@ class HooksProcessorTest {
         result.runCompiledAssertions()
     }
 
+    @Test fun `generates bail hook class`() {
+        val testHooks = SourceFile.kotlin(
+            "TestBailHooks.kt",
+            """
+            import com.intuit.hooks.BailResult
+            import com.intuit.hooks.Hook
+            import com.intuit.hooks.dsl.Hooks
+            
+            internal abstract class TestBailHooks : Hooks() {
+                @SyncBail<(String) -> BailResult<String>>
+                abstract val testSyncBailHook: Hook
+            }
+            """
+        )
+
+        val assertions = SourceFile.kotlin(
+            "Assertions.kt",
+            """
+            import com.intuit.hooks.BailResult
+            import org.junit.jupiter.api.Assertions.*
+
+            fun testHook() {
+                val hooks = TestBailHooksImpl()
+                hooks.testSyncBailHook.tap("test") { _, _ -> BailResult.Continue() }
+                val result = hooks.testSyncBailHook.call("hello") { str ->
+                    str + " world"
+                }
+                assertEquals("hello world", result)
+            }
+            """
+        )
+
+        val (compilation, result) = compile(testHooks, assertions)
+        result.assertOk()
+        compilation.assertKspGeneratedSources("TestBailHooksHooks.kt")
+        result.runCompiledAssertions()
+    }
+
     @Test fun `generates nested hook class`() {
         val testHooks = SourceFile.kotlin(
             "TestHooks.kt",


### PR DESCRIPTION
<!-- PR Template
Thank you for contributing! Please read through the following **before** opening your PR.
* Verify you have read the Contribution Guidelines on the ./CONTRIBUTING.md document
-->

# What Changed

Added a default handler to SyncBailHook `call` to automatically handle non-bail cases

## Why

Provide a default behaviour for when all the taps continue

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add release notes

# Release Notes

Allows for `SyncBailHook` to call with a default handler for when the taps do not bail and return nothing

<!-- GITHUB_RELEASE PR BODY: canary-version -->
📦 Published PR as canary version: <code>0.14.1-canary.33.350-SNAPSHOT</code>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
